### PR TITLE
Adjust the Slack messages to include URLs and dump the long html descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,7 @@ cp config/config.yml.example config/config.yml
 
 Set-up your development data base, I am using mysql locally but included an example SQLite DB config for lowest overhead
 ```
-cp config/database.yml.example config/database.yml
-bundle exec rake db:create
-bundle exec rake db:migrate
+bundle exec rake setup
 ```
 
 Compile the required JavaScript assets.

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -116,7 +116,11 @@ class Event < ActiveRecord::Base
     return self.where(live: true)
   end
 
+  def url
+    Rails.application.routes.url_helpers.event_url(self)
+  end
+
   def slack_message
-    "A new event has been created: #{title}. #{description}"
+    "A new event has been created: #{title}. #{url}"
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -122,11 +122,15 @@ class Project < ActiveRecord::Base
     db_presentation
   end
 
+  def url
+    Rails.application.routes.url_helpers.project_url(self)
+  end
+
   def slack_message
     if self.event.present?
-      "A new project #{title} has been submitted for #{event.title}. #{description}"
+      "A new project #{title} has been submitted for #{event.title}. #{url}"
     else
-      "A new project #{title} has been submitted to the backlog. #{description}"
+      "A new project #{title} has been submitted to the backlog. #{url}"
     end
   end
 

--- a/app/models/project_comment.rb
+++ b/app/models/project_comment.rb
@@ -14,8 +14,12 @@ class ProjectComment < ActiveRecord::Base
 
   default_scope { order(:created_at)}
 
+  def url
+    Rails.application.routes.url_helpers.project_project_comment_url(project_id,id)
+  end
+
   def slack_message
-    "#{user.name} has commented on #{project.title}: #{description}"
+    "#{user.name} has commented on #{project.title}: #{url}"
   end
 
   def send_notification

--- a/app/models/project_rating.rb
+++ b/app/models/project_rating.rb
@@ -10,6 +10,6 @@ class ProjectRating < ActiveRecord::Base
   delegate :id, to: :organization, prefix: true
 
   def slack_message
-    "#{user.name} liked project: #{project.title}"
+    "#{user.name} liked project #{project.title}: #{project.url}"
   end
 end

--- a/app/models/project_volunteer.rb
+++ b/app/models/project_volunteer.rb
@@ -21,6 +21,6 @@ class ProjectVolunteer < ActiveRecord::Base
   end
 
   def slack_message
-    "#{user.name} has volunteered for #{project.title}"
+    "#{user.name} has volunteered for #{project.title}: #{project.url}"
   end
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,5 +3,7 @@ require File.expand_path('../application', __FILE__)
 
 APP_CONFIG = YAML::load(File.open(Rails.root.join "config", "config.yml"))[Rails.env]
 
+Rails.application.routes.default_url_options[:host] = APP_CONFIG['domain']
+
 # Initialize the rails application
 CampusCodefest::Application.initialize!

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -1,0 +1,21 @@
+desc "Set up application from fresh checkout"
+task :setup => ["setup:setup"]
+namespace :setup do
+  task :setup do
+    Rake::Task['setup:configs'].invoke
+    Rake::Task['db:create'].invoke
+    Rake::Task['db:migrate'].invoke
+  end
+  
+  desc "Copy example config files"
+  task :configs do
+    file_pattern = File.join(File.expand_path("../../..", __FILE__), "config", "*.yml.example")
+    Dir.glob(file_pattern).each do |example_path|
+      config_path = example_path.gsub(".example", "")
+      unless File.exist? config_path
+        FileUtils.cp example_path, config_path
+        puts "copied #{config_path}"
+      end
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -6,15 +6,15 @@ describe Event do
   it "should require a start date" do
     should validate_presence_of(:start_date)
   end
-  
+
   it "should require an end date" do
     should validate_presence_of(:end_date)
   end
-  
+
   it "should require a title" do
     should validate_presence_of(:title)
   end
-  
+
   it "should require a description" do
     should validate_presence_of(:description)
   end
@@ -30,25 +30,40 @@ describe Event do
   it "should require a registration max" do
     should validate_presence_of(:registration_maximum)
   end
-  
+
   it "should accept a voting end date" do
     should allow_value(Time.now).for(:voting_end_date)
   end
-  
+
   it "should not accept a non-date for voting end date" do
     should_not allow_value("Some random trash").for(:voting_end_date)
   end
-  
+
   it "should have many projects" do
     should have_many(:projects)
   end
-  
+
   it "should have moderators" do
     should have_many(:moderators)
   end
-  
+
   it "should have many registrations" do
     should have_many(:registrations)
+  end
+
+  context "#url" do
+    subject { create(:event, organization: organization, title: "A Title") }
+    it "generates the proper url" do
+      expect(subject.url).to eq("http://lvh.me/events/1-a-title")
+    end
+  end
+
+  context "#slack_message" do
+    subject { create(:event, organization: organization, title: "A Title") }
+    it "generates a nice looking slack message" do
+      allow(subject).to receive(:url) { "http://example.com" }
+      expect(subject.slack_message).to match("A new event has been created: A Title. http://example.com")
+    end
   end
 
   context "input_<date> fields" do
@@ -75,45 +90,45 @@ describe Event do
       end
 
   end
-  
+
   describe "when dealing with voting for projects" do
     it "should be able to enable voting for projects" do
       @event = create(:event, voting_end_date: Date.tomorrow, voting_enabled: true, start_date: Date.tomorrow)
       expect(@event.voting_enabled?).to be true
     end
-  
+
     it "should be able to disable voting for projects" do
       @event = create(:event, voting_end_date: Date.tomorrow, voting_enabled: 0)
       expect(@event.voting_enabled?).to be false
     end
-  
+
     it "should not allow voting after voting end date" do
       @event = create(:event, voting_end_date: Date.today, voting_enabled: true)
       expect(@event.voting_enabled?).to be false
     end
-    
+
     it "should not accept votes if event start date has passed" do
       @event = create(:event, start_date: Date.today, voting_enabled: true, voting_end_date: Date.today)
-      expect(@event.voting_enabled?).to be false      
-    end 
+      expect(@event.voting_enabled?).to be false
+    end
   end
-  
+
   describe "when dealing with volunteering for projects" do
     it "should be able to enable volunteers for projects" do
       @event = create(:event, volunteer_end_date: Date.tomorrow, volunteering_enabled: true, end_date: Date.tomorrow)
       expect(@event.volunteering_enabled?).to be true
     end
-    
+
     it "should be able to disable volunteers for projects" do
       @event = create(:event, volunteer_end_date: Date.tomorrow, volunteering_enabled: false, end_date: Date.tomorrow)
       expect(@event.volunteering_enabled?).to be false
     end
-    
+
     it "should not allow volunteering after volunteer end date" do
       @event = create(:event, volunteer_end_date: Date.today, volunteering_enabled: true, end_date: Date.tomorrow)
       expect(@event.volunteering_enabled?).to be false
     end
-    
+
     it "should not accept votes if event end date has passed" do
       @event = create(:event, volunteer_end_date: Date.today, volunteering_enabled: true, end_date: Date.today.advance(:days => -1))
       expect(@event.volunteering_enabled?).to be false
@@ -137,17 +152,17 @@ describe Event do
         expect(@project.volunteer_count).to eq 0
         create(:project_volunteer, project: @project, user: @user)
         expect(@project.volunteer_count).to eq 1
-      end    
+      end
 
       it "should properly determine if a user is registered" do
         @event_registration = create(:event_registration, user: @user, event: @event)
-        expect(@event.registered?(@user)).to be true 
+        expect(@event.registered?(@user)).to be true
       end
 
       it "should properly determine the number of registrations remaining" do
         @event_registration = create(:event_registration, user: @user, event: @event)
         expect(@event.registrations_remaining).to eq 125
-      end      
+      end
     end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -6,26 +6,26 @@ describe Organization do
 
   it "should properly identify org admins" do
     create(:organization_user, user: user, organization: subject, admin: true)
-    subject.admin?(user).should == true
+    expect(subject.admin?(user)).to be true
   end
 
   it "should properly identify org non-admins" do
     create(:organization_user, user: user, organization: subject, admin: false)
-    subject.admin?(user).should == false
+    expect(subject.admin?(user)).to be false
   end
 
   it "should properly identify org verified members" do
     create(:organization_user, user: user, organization: subject, verified: true)
-    subject.verified?(user).should == true
+    expect(subject.verified?(user)).to be true
   end
 
   it "should properly identify org unverified members" do
     create(:organization_user, user: user, organization: subject, verified: false)
-    subject.verified?(user).should == false
+    expect(subject.verified?(user)).to be false
   end
 
   it "should properly identify org members" do
     create(:organization_user, user: user, organization: subject, verified: true)
-    subject.member?(user).should == true
+    expect(subject.member?(user)).to be true
   end
 end

--- a/spec/models/project_comment_spec.rb
+++ b/spec/models/project_comment_spec.rb
@@ -2,8 +2,30 @@ require_relative '../spec_helper'
 
 describe ProjectComment do
   it "attempts to deliver emails when a project is commented upon" do
-    project_comment = build :project_comment 
+    project_comment = build :project_comment
     expect(project_comment).to receive(:send_notification)
     project_comment.save
+  end
+
+  context "#url" do
+      let(:organization) { create :organization }
+      subject { create(:project_comment, project: create(:project, project_owner: create(:user), organization: organization, title: "Project"))  }
+    it "generates the proper url" do
+      expect(subject.url).to eq("http://lvh.me/projects/1/project_comments/1")
+    end
+  end
+
+  context "#slack_message" do
+    let(:organization) { create :organization }
+    describe "with an event" do
+      subject { create(:project_comment, project: create(:project, project_owner: create(:user), organization: organization, title: "Project"))  }
+      it "generates a nice looking slack message" do
+        user = double
+        allow(subject).to receive(:url) { "http://example.com" }
+        allow(subject).to receive(:user) { user }
+        allow(user).to receive(:name) { "Bob" }
+        expect(subject.slack_message).to match("Bob has commented on Project: http://example.com")
+      end
+    end
   end
 end

--- a/spec/models/project_rating_spec.rb
+++ b/spec/models/project_rating_spec.rb
@@ -7,4 +7,14 @@ describe ProjectRating do
   it "should require a description"
   it "should allow one comment per user/project combination"
   it "should be editable and deletable by mod"
+
+  context "#slack_message" do
+  let(:organization) { create :organization }
+    subject { create(:project_rating, user: build(:user, name: "Bob"), project: create(:project, organization: organization, title: "Project") ) }
+    it "generates a nice looking slack message" do
+      allow(subject.project).to receive(:url) { "http://example.com" }
+      expect(subject.slack_message).to match("Bob liked project Project: http://example.com")
+    end
+  end
+
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -5,91 +5,115 @@ describe Project do
   it "should require a title" do
     should validate_presence_of(:title)
   end
-  
+
   it "should require a description" do
     should validate_presence_of(:description)
   end
-  
+
   it "should allow a project owner or accept none" do
     should allow_value(nil).for(:project_owner)
     should allow_value(1).for(:project_owner_id)
   end
-  
+
   it "should not require a classification" do
-    should_not validate_presence_of(:classification)    
+    should_not validate_presence_of(:classification)
   end
 
   it "should have volunteers" do
     should have_many(:volunteers)
   end
-  
+
   it "should have comments" do
     should have_many(:volunteers)
   end
-  
+
   it "should have ratings" do
     should have_many(:ratings)
   end
-  
+
   it "should belong to an event" do
     should belong_to(:event)
   end
-  
+
   it "should have tags" do
     should have_many(:tags)
   end
-      
+
+  context "#slack_message" do
+    describe "with an event" do
+      subject { create(:project, organization: organization, title: "A Title") }
+      it "generates a nice looking slack message" do
+        allow(subject).to receive(:url) { "http://example.com" }
+        expect(subject.slack_message).to match("A new project A Title has been submitted to the backlog. http://example.com")
+      end
+    end
+    describe "without an event" do
+      let(:event) { create(:event,
+                           title: "Event Title",
+                           start_date: Date.today.advance(:days => 5),
+                           voting_enabled: true,
+                           voting_end_date: Date.tomorrow)
+      }
+      subject { create(:project, organization: organization, event: event, title: "A Title") }
+
+      it "generates a nice looking slack message" do
+        allow(subject).to receive(:url) { "http://example.com" }
+        expect(subject.slack_message).to match("A new project A Title has been submitted for Event Title. http://example.com")
+      end
+
+    end
+  end
   describe "that belongs to an event" do
     it "should allow votes if event accepts votes" do
       @event = create(:event, start_date: Date.today.advance(:days => 5),
                             voting_enabled: true,
                             voting_end_date: Date.tomorrow)
-                            
+
       @project = create(:project, organization: organization, event: @event)
-      
+
       expect(@project.voting_allowed?).to be true
     end
-    
+
     it "should not allow votes if event does not accept votes" do
       @event = create(:event, start_date: Date.today.advance(:days => 5),
                             voting_enabled: true,
                             voting_end_date: Date.today.advance(:days => -2))
-                            
+
       @project = create(:project, organization: organization, event: @event)
-      
+
       expect(@project.voting_allowed?).to be false
     end
-    
+
     it "should allow volunteers if event accepts volunteers" do
       @event = create(:event, end_date: Date.today.advance(:days => 5),
                             volunteering_enabled: true,
                             volunteer_end_date: Date.tomorrow)
-                            
+
       @project = create(:project, organization: organization, event: @event)
-      
+
       expect(@project.volunteering_allowed?).to be true
     end
-    
+
     it "should not allow volunteers if event accepts volunteers" do
       @event = create(:event, end_date: Date.today.advance(:days => 5),
                             volunteering_enabled: true,
                             volunteer_end_date: Date.yesterday)
-                            
+
       @project = create(:project, organization: organization, event: @event)
-      
+
       expect(@project.volunteering_allowed?).to be false
-    end    
+    end
   end
-  
+
   describe "that does not belong to an event" do
     it "should not accept votes" do
       @project = create(:project, organization: organization)
-      expect(@project.voting_allowed?).to be false      
+      expect(@project.voting_allowed?).to be false
     end
-    
+
     it "should not accept volunteers" do
       @project = create(:project, organization: organization)
-      expect(@project.volunteering_allowed?).to be false      
+      expect(@project.volunteering_allowed?).to be false
     end
   end
 
@@ -104,7 +128,7 @@ describe Project do
       @project = create(:project, organization: organization, :event => @event)
     end
 
-    it "should determine if a user has voted on a project" do 
+    it "should determine if a user has voted on a project" do
       expect(@project.voted_on?(@user)).to be false
       @project_rating = create(:project_rating, user: @user, project: @project)
       expect(@project.voted_on?(@user)).to be true
@@ -143,7 +167,7 @@ describe Project do
       expect(lambda{@project.unvolunteer(@user)}).to_not change(ProjectVolunteer, :count)
     end
   end
-  
+
   # Need to get knowledge of GitHub API here. Contact Debbie G at UMN CSE
   it "should associate a github account"
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -39,6 +39,13 @@ describe Project do
     should have_many(:tags)
   end
 
+  context "#url" do
+    subject { create(:project, organization: organization, title: "A Title") }
+    it "generates the proper url" do
+      expect(subject.url).to eq("http://lvh.me/projects/1-a-title")
+    end
+  end
+
   context "#slack_message" do
     describe "with an event" do
       subject { create(:project, organization: organization, title: "A Title") }

--- a/spec/models/project_volunteer_spec.rb
+++ b/spec/models/project_volunteer_spec.rb
@@ -5,8 +5,20 @@ describe ProjectVolunteer do
   it "should belong to a user"
   it "should notify the project owner when created"
   it "should notify the project owner when destroyed"
-  
+
   it "should be unique between a user and project"
   it "should not be allowed if project does not have an event"
-  it "should not be allowed if project event expired" 
+  it "should not be allowed if project event expired"
+
+  context "#slack_message" do
+    before do
+      ProjectVolunteer.skip_callback(:validate, :limit_projects)
+    end
+    let(:organization) { create :organization }
+    subject { create(:project_volunteer, user: build(:user, name: "Bob"), project: create(:project, organization: organization, title: "Project") ) }
+    it "generates a nice looking slack message" do
+      allow(subject.project).to receive(:url) { "http://example.com" }
+      expect(subject.slack_message).to match("Bob has volunteered for Project: http://example.com")
+    end
+  end
 end


### PR DESCRIPTION
This PR mostly updates the slack integration to have a more concise message that includes a url to the object or relevant object that generated it.

Secondarily I fixed some spec deprecation warnings for the rspec 2 style tests

And Add a `rake setup` to bootstrap the project, and have updated the README accordingly

The one sort of risky thing done here is I added 

```ruby
Rails.application.routes.default_url_options[:host] = APP_CONFIG['domain']
```

To the environment.rb. This allows the url helpers to work properly without needing a `:host` option.